### PR TITLE
migrate to swift5

### DIFF
--- a/SoundWaveForm.xcodeproj/project.pbxproj
+++ b/SoundWaveForm.xcodeproj/project.pbxproj
@@ -325,7 +325,7 @@
 				TargetAttributes = {
 					E5B0ECF61F238A40005D1A58 = {
 						CreatedOnToolsVersion = 8.3.3;
-						LastSwiftMigration = 0920;
+						LastSwiftMigration = 1130;
 						ProvisioningStyle = Automatic;
 					};
 					E5B0ED561F238B6B005D1A58 = {
@@ -625,7 +625,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -649,7 +649,7 @@
 				PRODUCT_NAME = SoundWaveForm;
 				SKIP_INSTALL = YES;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/Sources/SamplesExtractor.swift
+++ b/Sources/SamplesExtractor.swift
@@ -6,8 +6,8 @@
 //
 //  https://github.com/fulldecent/FDWaveformView
 //  https://github.com/dmrschmidt/DSWaveformImage
-//  ... 
-//  
+//  ...
+//
 //  - added supports iOS & macOS
 //  - ability to setup a timeRange to restrict automatically the zone of interest.
 //  - improved performance
@@ -31,7 +31,7 @@ public enum SamplesExtractorError: Error {
 
 public struct SamplesExtractor{
 
-    
+
     public fileprivate(set) static var outputSettings: [String : Any] = [
         AVFormatIDKey: kAudioFormatLinearPCM,
         AVLinearPCMBitDepthKey: 16,


### PR DESCRIPTION
Hello, I'm pretty new to swift development and wanted to use your library. Unfortunately I was not able to add it to my project using Carthage with the error:

```
Build Failed
	Task failed with exit code 65:
	/usr/bin/xcrun xcodebuild -project /Users/juliensanchez/workspace/projects/swiftUI/RecorderPOC2/Carthage/Checkouts/SoundWaveForm/SoundWaveForm.xcodeproj -scheme SoundWaveForm -configuration Release -derivedDataPath /Users/juliensanchez/Library/Caches/org.carthage.CarthageKit/DerivedData/11.3.1_11C504/SoundWaveForm/v4.0.2 ONLY_ACTIVE_ARCH=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= CARTHAGE=YES archive -archivePath /var/folders/mj/jj1hz3rs6xnfjr4ygh0wm6180000gn/T/SoundWaveForm SKIP_INSTALL=YES GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=NO CLANG_ENABLE_CODE_COVERAGE=NO STRIP_INSTALLED_PRODUCT=NO (launched in /Users/juliensanchez/workspace/projects/swiftUI/RecorderPOC2/Carthage/Checkouts/SoundWaveForm)

This usually indicates that project itself failed to compile. Please check the xcodebuild log for more details: /var/folders/mj/jj1hz3rs6xnfjr4ygh0wm6180000gn/T/carthage-xcodebuild.9vDwJZ.log
```

This changes to the project seems to fix the problem. Hope this helps :)